### PR TITLE
adjust for Neos 9.1 UI

### DIFF
--- a/Resources/Private/JavaScript/AxeCoreView/src/manifest.js
+++ b/Resources/Private/JavaScript/AxeCoreView/src/manifest.js
@@ -11,12 +11,25 @@ manifest('Prgfx.Neos.AxeCore:AxeCoreView', {}, (globalRegistry, { frontendConfig
         component: AxeCoreView,
     });
 
-    const previewModes = frontendConfiguration.editPreviewModes;
-    Object.entries(previewModes).forEach(([ key, value ]) => {
-        if (value.hidden) {
-            delete previewModes[key];
-        }
-    });
+    // omit "hidden" preview modes
+    let previewModes = null;
+    // Neos 9.1 deprecated the frontendConfiguration and editPreviewModes is no longer available
+    // We don't require a neos version that has the import, so we do try the manual way
+    const getConfiguration = window['@Neos:HostPluginAPI']?.['@NeosProjectPackages']()['NeosUiConfiguration']?.getConfiguration;
+    if (typeof getConfiguration === 'function') {
+        // the intended way would be using the function with a selector callback, but we want the original object to modify it
+        const frontendConfiguration = getConfiguration();
+        previewModes = frontendConfiguration.editPreviewModes;
+    } else if (frontendConfiguration && 'editPreviewModes' in frontendConfiguration) {
+        previewModes = frontendConfiguration.editPreviewModes;
+    }
+    if (previewModes) {
+        Object.entries(previewModes).forEach(([ key, value ]) => {
+            if (value.hidden) {
+                delete previewModes[key];
+            }
+        });
+    }
 
     const sagasRegistry = globalRegistry.get('sagas');
     sagasRegistry.set('Prgfx.Neos.AxeCore/analyze', { saga: handleAnalyzerRequest });

--- a/Resources/Public/JavaScript/AxeCoreView/Plugin.js
+++ b/Resources/Public/JavaScript/AxeCoreView/Plugin.js
@@ -1764,12 +1764,21 @@
     viewsRegistry.set("Prgfx.Neos.AxeCore/Inspector/Views/AxeCoreView", {
       component: AxeCoreView
     });
-    const previewModes = frontendConfiguration.editPreviewModes;
-    Object.entries(previewModes).forEach(([key, value]) => {
-      if (value.hidden) {
-        delete previewModes[key];
-      }
-    });
+    let previewModes = null;
+    const getConfiguration = window["@Neos:HostPluginAPI"]?.["@NeosProjectPackages"]()["NeosUiConfiguration"]?.getConfiguration;
+    if (typeof getConfiguration === "function") {
+      const frontendConfiguration2 = getConfiguration();
+      previewModes = frontendConfiguration2.editPreviewModes;
+    } else if (frontendConfiguration && "editPreviewModes" in frontendConfiguration) {
+      previewModes = frontendConfiguration.editPreviewModes;
+    }
+    if (previewModes) {
+      Object.entries(previewModes).forEach(([key, value]) => {
+        if (value.hidden) {
+          delete previewModes[key];
+        }
+      });
+    }
     const sagasRegistry = globalRegistry.get("sagas");
     sagasRegistry.set("Prgfx.Neos.AxeCore/analyze", { saga: handleAnalyzerRequest });
     const reducersRegistry = globalRegistry.get("reducers");


### PR DESCRIPTION
Getting and changing the available preview modes has changed with the 9.1 UI. We still want to be backwards compatible to not maintain multiple versions, so we work around the changes.

I'm not completely sure in which way the frontendConfiguration (-registry) is deprecated and might be removed, but as there doesn't even seem to be a released version with the new consumer api shims for the new configuration functions, I leave the problem to haunt me later.

resolves #5 